### PR TITLE
ci: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build site
+        run: bash compile.sh
+
+      - name: Prepare Pages artifact
+        run: |
+          mkdir public
+          mv mikupad_compiled.html public/index.html
+          mv mikupad_compiled.css public/
+          mv mikupad_compiled.js public/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ open mikupad.html
 ```
 To use **mikupad** fully offline, run the provided `compile` script or download the pre-compiled `mikupad_compiled.html` file from [Releases](https://github.com/lmg-anon/mikupad/releases/latest). The compiled build bundles the app with Parcel, producing `mikupad_compiled.html`, `mikupad_compiled.css`, and `mikupad_compiled.js` so it can run without external dependencies.
 
-You can also [try it on GitHub Pages](https://lmg-anon.github.io/mikupad/mikupad.html).
+You can also [try it on GitHub Pages](https://lmg-anon.github.io/mikupad/).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow to compile and publish mikupad
- update README with GitHub Pages link

## Testing
- `bash compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aaf20fe2f08331aed5297bac47c671